### PR TITLE
Refactor CI/CD workflow for backend: rename job, add build step, and …

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -1,4 +1,4 @@
-name: Backend CI/CD
+name: Backend CI
 
 on:
   push:
@@ -12,7 +12,7 @@ on:
 
 jobs:
   test:
-    name: Test Backend
+    name: Test & Build Backend
     runs-on: ubuntu-latest
 
     services:
@@ -64,36 +64,44 @@ jobs:
         env:
           DATABASE_URL: postgresql://postgres:postgres@localhost:5432/wallzen_test
           NODE_ENV: test
-          JWT_SECRET: test_secret
-
-  deploy:
-    name: Deploy Backend
-    needs: test
-    if: github.ref == 'refs/heads/main'
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v3
-        with:
-          node-version: '18'
-
-      - name: Install Dependencies
-        working-directory: backend
-        run: npm ci
 
       - name: Build Application
         working-directory: backend
         run: npm run build
 
-      # Add your deployment steps here
-      # Example for Railway deployment:
-      - name: Deploy to Railway
-        working-directory: backend
-        run: |
-          npm install -g @railway/cli
-          railway up
+      - name: Upload Build Artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: backend-build
+          path: backend/dist
+
+  create-release:
+    needs: test
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Download Build Artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: backend-build
+          path: backend/dist
+
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
         env:
-          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: backend-v${{ github.run_number }}
+          release_name: Backend Release v${{ github.run_number }}
+          body: |
+            Backend Release v${{ github.run_number }}
+            
+            Changes in this release:
+            ${{ github.event.head_commit.message }}
+            
+            Build Date: ${{ env.DATE }}
+          draft: false
+          prerelease: false


### PR DESCRIPTION
This pull request includes several updates to the backend CI workflow to improve the build and release process. The most important changes involve renaming jobs, adding build and upload steps, and creating a new release job.

Improvements to the CI workflow:

* [`.github/workflows/backend-ci.yml`](diffhunk://#diff-d30b4e6a2bd3c346243a103c773373348c1bf4a80af7bf92f854306c597fca6bL1-R1): Renamed the workflow from "Backend CI/CD" to "Backend CI".
* [`.github/workflows/backend-ci.yml`](diffhunk://#diff-d30b4e6a2bd3c346243a103c773373348c1bf4a80af7bf92f854306c597fca6bL15-R15): Renamed the "Test Backend" job to "Test & Build Backend" and added steps to build the application and upload the build artifact [[1]](diffhunk://#diff-d30b4e6a2bd3c346243a103c773373348c1bf4a80af7bf92f854306c597fca6bL15-R15) [[2]](diffhunk://#diff-d30b4e6a2bd3c346243a103c773373348c1bf4a80af7bf92f854306c597fca6bL67-R107).

Enhancements to the release process:

* [`.github/workflows/backend-ci.yml`](diffhunk://#diff-d30b4e6a2bd3c346243a103c773373348c1bf4a80af7bf92f854306c597fca6bL67-R107): Removed the "Deploy Backend" job and added a new "create-release" job that downloads the build artifact and creates a GitHub release with details about the release and build date.…create release process